### PR TITLE
Ensure that the User-Agent header is always present when making HTTP requests

### DIFF
--- a/rssdiscoveryengine_app/headers.py
+++ b/rssdiscoveryengine_app/headers.py
@@ -1,0 +1,4 @@
+USER_AGENT = 'RSS Discovery Engine 0.1'
+HTTP_HEADERS = {
+    'User-Agent': USER_AGENT,
+}

--- a/rssdiscoveryengine_app/rssfinder.py
+++ b/rssdiscoveryengine_app/rssfinder.py
@@ -4,6 +4,7 @@ import feedparser
 import requests
 from bs4 import BeautifulSoup
 
+from rssdiscoveryengine_app.headers import HTTP_HEADERS
 from rssfinderasync.rssfinderhelpers import build_possible_rss_url
 
 # Autoreload imported scripts without restarting the repl:
@@ -16,16 +17,12 @@ ignore = [
 	'https://t.co',
 	'https://www.instagram.com'
 ]
-agent = 'RSS Discovery Engine 0.1'
-request_headers = {
-	'User-Agent': agent
-}
 
 
 def find_links(url):
 	feeds = []
 	discarded = []
-	result = feedparser.parse(url)
+	result = feedparser.parse(url, request_headers=HTTP_HEADERS)
 
 	if result.bozo > 0:
 		# there were errors parsing the feed
@@ -65,7 +62,7 @@ def find_links(url):
 				discarded.append(link)
 				continue
 
-			found_rss_result = feedparser.parse(rss_url)
+			found_rss_result = feedparser.parse(rss_url, request_headers=HTTP_HEADERS)
 			if found_rss_result.bozo > 0:
 				discarded.append(link)
 				continue
@@ -149,7 +146,7 @@ def find_rss_url(original_url):
 	return rss_link
 
 def get_request(url):
-	return requests.get(url, headers=request_headers)
+	return requests.get(url, headers=HTTP_HEADERS)
 
 def find_anchors(entry):
 	soup = BeautifulSoup(entry.description, "html.parser")

--- a/rssfinderasync/rfasync.py
+++ b/rssfinderasync/rfasync.py
@@ -1,8 +1,11 @@
 import asyncio
+
 import aiohttp
-from aiohttp import ClientSession
 import feedparser
-from . import rssfinderhelpers as helpers
+
+from rssdiscoveryengine_app.headers import HTTP_HEADERS
+from rssfinderasync import rssfinderhelpers as helpers
+
 
 async def fetch(blog_url, session):
     rss_url = None
@@ -44,7 +47,7 @@ async def run(urls):
     sem = asyncio.Semaphore(1000)
     tasks = []
     timeout = aiohttp.ClientTimeout(total=10)
-    async with ClientSession(timeout=timeout) as session:
+    async with aiohttp.ClientSession(timeout=timeout, headers=HTTP_HEADERS) as session:
         for url in urls:
             task = asyncio.ensure_future(
                 fetch_bound_async(sem, url, session)

--- a/rssfinderasync/rssfinderhelpers.py
+++ b/rssfinderasync/rssfinderhelpers.py
@@ -4,11 +4,13 @@ import feedparser
 import requests
 from bs4 import BeautifulSoup
 
+from rssdiscoveryengine_app.headers import HTTP_HEADERS
+
 
 def get_response_content(url):
     response = None
     try:
-        response = requests.get(url)
+        response = requests.get(url, headers=HTTP_HEADERS)
     except:
         return
 
@@ -51,7 +53,7 @@ def add_protocol_urlprefix(blog_url, rss_url):
     return rss_url
 
 def get_urls_from_rss_feed(rss_url):
-    feed = feedparser.parse(rss_url)
+    feed = feedparser.parse(rss_url, request_headers=HTTP_HEADERS)
     if feed.bozo > 0:
         return
 


### PR DESCRIPTION
RSS Discovery Engine does HTTP requests in several different ways:

1) `aiohttp`
2) the `get_response_content` function
3) the `get_request` function
4) whatever `feedparser` uses internally

Only `get_request` was setting the `User-Agent` header. Not setting a user agent (or using the default one from the lib) is a fairly reliable way to trip bad-bot-detection alarms; I am reasonably sure this is _part_ of why it [struggles to work with HN](https://news.ycombinator.com/item?id=28968119).

This changeset ensures that it always sets the header, however the request is made.
 
Driveby: order some imports and remove an unused one.