### PR TITLE
Rename `is_rss_content_type` to `is_feed_content_type` and simplify it somewhat

### DIFF
--- a/rssfinderasync/rfasync.py
+++ b/rssfinderasync/rfasync.py
@@ -27,7 +27,7 @@ async def fetch(blog_url, session):
     try:
         async with session.get(rss_url) as response:
             if response.status != 200 \
-            or not helpers.is_rss_content_type(response.headers["Content-Type"]):
+            or not helpers.is_feed_content_type(response.headers["Content-Type"]):
                 return
 
             feed = feedparser.parse(await response.read())

--- a/rssfinderasync/rssfinderhelpers.py
+++ b/rssfinderasync/rssfinderhelpers.py
@@ -80,7 +80,7 @@ def find_anchors(entry):
 def is_valid_url(url):
     return url and url.startswith("http")
 
-def is_rss_content_type(content_type):
+def is_feed_content_type(content_type):
     if content_type.startswith("application/rss") \
     or content_type.startswith("application/atom") \
     or content_type.startswith("application/xml"):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,9 +1,23 @@
-from rssfinderasync.rssfinderhelpers import build_possible_rss_url
+import pytest
+
+import rssfinderasync.rssfinderhelpers as helpers
 
 
 def test_build_possible_rss_url():
-    assert build_possible_rss_url('mailto:rdengine@example.invalid') is None
-    assert build_possible_rss_url('https://example.invalid/') == 'https://example.invalid/feed'
-    assert build_possible_rss_url('https://example.invalid/subpath/') == 'https://example.invalid/feed'
-    assert build_possible_rss_url('https://example.invalid/?q=5') == 'https://example.invalid/feed'
-    assert build_possible_rss_url('https://example.invalid/#fragment') == 'https://example.invalid/feed'
+    assert helpers.build_possible_rss_url('mailto:rdengine@example.invalid') is None
+    assert helpers.build_possible_rss_url('https://example.invalid/') == 'https://example.invalid/feed'
+    assert helpers.build_possible_rss_url('https://example.invalid/subpath/') == 'https://example.invalid/feed'
+    assert helpers.build_possible_rss_url('https://example.invalid/?q=5') == 'https://example.invalid/feed'
+    assert helpers.build_possible_rss_url('https://example.invalid/#fragment') == 'https://example.invalid/feed'
+
+
+
+@pytest.mark.parametrize('content_type, expected', [
+    ('application/rss', True),
+    ('application/rss; charset=UTF-8', True),
+    ('application/atom', True),
+    ('application/xml', True),
+    ('text/html', False),
+])
+def test_is_feed_content_type(content_type, expected):
+    assert helpers.is_feed_content_type(content_type) is expected


### PR DESCRIPTION
Pardon the pull request spam; this is rooted in pedantry, the fact I like this project, and my deep-rooted desire to make extra work for myself.

I felt that `is_rss_content_type` was misnamed, so I renamed it. I also thought it could be simplified a little, so I simplified it a little. As with #7 (these will conflict when one of these is merged - and don't worry, I'll fix it), I've added a pytest dependency into the project so that you can have tests, and added a test to ensure that the function's behaviour is unchanged.

Thank you!