### PR TITLE
Make header clickable

### DIFF
--- a/rssdiscoveryengine_app/templates/home.html
+++ b/rssdiscoveryengine_app/templates/home.html
@@ -155,6 +155,11 @@
 				font-size: 0.8em;
 			}
 
+			a.nolink, a.nolink:hover, a.nolink:active {
+				color: #3b3b3b;
+				text-decoration: none;
+			}
+
 			/* Responsive Styles */
 
 			@media only screen and (max-width: 480px) {
@@ -173,7 +178,9 @@
 			<div class="bubble"></div>
 		</div>
 		<div class="wrapper">
-			<h1>RSS Discovery Engine  <em>pre-alpha</em></h1>
+			<a href="/" class="nolink">
+				<h1>RSS Discovery Engine  <em>pre-alpha</em></h1>
+			</a>
 			<form method="GET" onsubmit="document.getElementById('loader').removeAttribute('style')">
 				<div id="search">
 					<input 


### PR DESCRIPTION
It's a common UI pattern on the web: the header title is clickable. It allows to quickly go to the main page.

This is quite handy when you want to clear out the results and start typing a fresh URL.

Demo:

https://user-images.githubusercontent.com/2031472/138573845-33a0ed55-80cc-4565-b2f3-744abc3c04f8.mov


