### PR TITLE
Add backlinks to the website and the article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # RSS Discovery Engine
 
-The RSS Discovery Engine exists to encourage people to use RSS for finding and consuming their news and current events.
+The [RSS Discovery Engine](https://rdengine.herokuapp.com/) exists to encourage people to use RSS for finding and consuming their news and current events.
 
 ![RSS Discovery Engine Screenshot](http://quakkels.com/images/rde_dark.png)
+
+Check it out here: [rdengine.herokuapp.com](https://rdengine.herokuapp.com/)
 
 ## Running RSS Discovery Engine locally
 
@@ -19,3 +21,6 @@ And then run the development server, which will make a development server access
 ```shell
 ./run.sh
 ```
+
+## Resources
+- [RSS is Wonderful](https://quakkels.com/posts/rss-is-wonderful/)


### PR DESCRIPTION
Added some backlinks to the production website and to the article introducing the RSS Discovery Engine.

This helps with SEO and also makes it easier to find the production website if you happen to only have GitHub repo open.

A link to the article added as because it has lot of info explaining the rationale behind the website.