### PR TITLE
Upgrade requests to 2.26

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -32,7 +32,7 @@ ptyprocess==0.6.0
 Pygments==2.7.4
 pylint==2.4.4
 pytest==6.2.5
-requests==2.22.0
+requests==2.26.0
 rope==0.14.0
 six==1.13.0
 soupsieve==1.9.5


### PR DESCRIPTION
https://github.com/quakkels/rssdiscoveryengine/pull/5 [broke the build](https://github.com/quakkels/rssdiscoveryengine/runs/3989610167?check_suite_focus=true), because 
```
The conflict is caused by:
    The user requested urllib3==1.26.5
    requests 2.22.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1
```

This PR upgrades requests to fix that